### PR TITLE
Emit error on app conditionally based on mapping status

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,9 @@ module.exports = function(mappers) {
         this.set(mapping.headers);
       }
 
-      // Emit error.
-      this.app.emit('error', e, this);
+      if (mapping.status >= 500) {
+        this.app.emit('error', e, this);
+      }
     }
   };
 };


### PR DESCRIPTION
This allows for much better error handling as mapped errors are considered handled and therefore do not need to be reported as errors on the applications.
