### PR TITLE
Emit all errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,7 @@ module.exports = function(mappers) {
         this.set(mapping.headers);
       }
 
-      if (mapping.status >= 500) {
-        this.app.emit('error', e, this);
-      }
+      this.app.emit('error', e, this);
     }
   };
 };

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -228,47 +228,7 @@ describe('ErrorMapper', () => {
       .end();
   });
 
-  it('should not emit an `error` event on app if mapping status is < 500', function *() {
-    const app = koa();
-
-    function HttpError(status) {
-      this.status = status;
-      this.expose = false;
-    }
-
-    HttpError.prototype.expose = () => {
-      return this.expose;
-    };
-
-    HttpError.prototype.status = () => {
-      return this.status;
-    };
-
-    HttpError.prototype.statusCode = () => {
-      return this.status;
-    };
-
-    let called = false;
-
-    app.on('error', () => {
-      called = true;
-    });
-
-    app.use(errorMapper());
-    app.use(function *() {
-      throw new HttpError(429);
-    });
-
-    yield request(app.listen())
-      .get('/')
-      .expect(429)
-      .expect(() => {
-        called.should.be.false();
-      })
-      .end();
-  });
-
-  it('should emit an `error` event on app if mapping status is >= 500', function *() {
+  it('should emit an `error` event on app', function *() {
     const app = koa();
     let called = false;
 


### PR DESCRIPTION
So that we can receive errors with status < 500 and treat them accordingly (e.g. logging).