### PR TITLE
Update HttpErrorMapper to support http-standard-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ Foo: Bar
 { "message": "Ah-ah!" }
 ```
 
+Support for instances of [standard-error](https://github.com/moll/js-standard-error) is also provided, just pass the error class you need to test against, for example:
+
+```js
+'use strict';
+
+const CustomMapper = require('path/to/my/custom/mapper');
+const HttpError = require('standard-http-error');
+const errorMapper = require('koa-error-mapper');
+const koa = require('koa');
+const app = koa();
+
+app.use(errorMapper([CustomMapper], HttpError);
+
+// Or just pass the error class if you don't have any custom mappers:
+app.use(errorMapper(HttpError));
+```
+
 ## Tests
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -11,8 +11,13 @@ const httpErrorMapper = require('./mappers/http-error-mapper');
  * Export `ErrorMapperMiddleware`.
  */
 
-module.exports = function(mappers) {
-  mappers = (mappers || []).concat([httpErrorMapper, fallbackErrorMapper]);
+module.exports = function(mappers, HttpError) {
+  if (typeof mappers === 'function') {
+    HttpError = mappers;
+    mappers = [];
+  }
+
+  mappers = (mappers || []).concat([httpErrorMapper(HttpError), fallbackErrorMapper]);
 
   function map(e) {
     let mapping;

--- a/mappers/http-error-mapper.js
+++ b/mappers/http-error-mapper.js
@@ -1,27 +1,26 @@
 'use strict';
 
 /**
- * Module dependencies.
+ * `HttpError` mapper.
  */
 
-const STATUS_CODE_TO_NAME = require('http').STATUS_CODES;
-
-/**
- * `Error` mapper.
- */
-
-module.exports.map = function(e) {
-  const proto = Object.getPrototypeOf(e);
-
-  if (!(proto.hasOwnProperty('expose') && proto.hasOwnProperty('status') && proto.hasOwnProperty('statusCode'))) {
-    return;
-  }
-
+module.exports = HttpError => {
   return {
-    body: {
-      code: STATUS_CODE_TO_NAME[e.status].replace(/\s+/g, '_').toLowerCase(),
-      message: e.expose ? e.message : STATUS_CODE_TO_NAME[e.status]
-    },
-    status: e.status
+    map(e) {
+      if (HttpError && !(e instanceof HttpError)) {
+        return;
+      } else if (!(e.status && e.statusCode)) {
+        return;
+      }
+
+      return {
+        body: {
+          code: e.message.replace(/\s+/g, '_').toLowerCase(),
+          message: e.message
+        },
+        headers: e.headers,
+        status: e.status
+      };
+    }
   };
 };

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "co-supertest": "^0.0.8",
     "eslint": "^3.11.1",
     "eslint-config-seegno": "^8.0.1",
-    "http-errors": "^1.3.1",
     "koa": "^0.18.1",
     "mocha": "^2.2.1",
     "pre-commit": "^1.1.2",
     "should": "^8.3.1",
+    "standard-http-error": "^2.0.0",
     "supertest": "^0.15.0"
   },
   "engines": {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const HttpError = require('standard-http-error');
 const errorMapper = require('../');
 const koa = require('koa');
 const request = require('co-supertest');
@@ -162,6 +163,24 @@ describe('ErrorMapper', () => {
       .expect(() => {
         called.should.be.false();
       })
+      .end();
+  });
+
+  it('should map given `HttpError` instances', function *() {
+    const app = koa();
+
+    app.on('error', noop);
+
+    app.use(errorMapper(HttpError));
+
+    app.use(function *() {
+      throw new HttpError(404);
+    });
+
+    yield request(app.listen())
+      .get('/')
+      .expect(404)
+      .expect({ code: 'not_found', message: 'Not Found' })
       .end();
   });
 

--- a/test/mappers/http-error-mapper_test.js
+++ b/test/mappers/http-error-mapper_test.js
@@ -4,8 +4,8 @@
  * Module dependencies.
  */
 
-const HttpError = require('http-errors');
-const mapper = require('../../mappers/http-error-mapper');
+const HttpError = require('standard-http-error');
+const httpErrorMapper = require('../../mappers/http-error-mapper');
 const should = require('should');
 
 /**
@@ -13,24 +13,43 @@ const should = require('should');
  */
 
 describe('HttpErrorMapper', () => {
-  it('should not map any error that is not an instance of `HttpError`', () => {
-    should.not.exist(mapper.map({}));
+  describe('when `HttpError` is not provided', () => {
+    const mapper = httpErrorMapper();
+
+    it('should not map any error that is not an instance of `HttpError`', () => {
+      should.not.exist(mapper.map({}));
+    });
+
+    it('should return a regular http message if `HttpError` only has a status code set', () => {
+      mapper.map(new HttpError(401)).should.eql({ body: { code: 'unauthorized', message: 'Unauthorized' }, headers: undefined, status: 401 });
+    });
+
+    it('should return `HttpError` message and its code in snake case format', () => {
+      mapper.map(new HttpError(401, 'Foo Bar')).should.eql({ body: { code: 'foo_bar', message: 'Foo Bar' }, headers: undefined, status: 401 });
+    });
+
+    it('should return `HttpError` headers', () => {
+      mapper.map(new HttpError(401, 'foo', { headers: { biz: 'baz' } })).should.eql({ body: { code: 'foo', message: 'foo' }, headers: { biz: 'baz' }, status: 401 });
+    });
   });
 
-  it('should not expose the message error if `HttpError` does not have a status code set', () => {
-    mapper.map(new HttpError('foo')).should.eql({ body: { code: 'internal_server_error', message: 'Internal Server Error' }, status: 500 });
-  });
+  describe('when `HttpError` is provided', () => {
+    const mapper = httpErrorMapper(HttpError);
 
-  it('should not expose the message error if `HttpError` does not have an exposable status code', () => {
-    mapper.map(new HttpError(503, 'Foo')).should.eql({ body: { code: 'service_unavailable', message: 'Service Unavailable' }, status: 503 });
-  });
+    it('should not map any error that is not an instance of `HttpError`', () => {
+      should.not.exist(mapper.map({}));
+    });
 
-  it('should return a regular http message if `HttpError` only has a status code set', () => {
-    mapper.map(new HttpError(401)).should.eql({ body: { code: 'unauthorized', message: 'Unauthorized' }, status: 401 });
-  });
+    it('should return a regular http message if `HttpError` only has a status code set', () => {
+      mapper.map(new HttpError(401)).should.eql({ body: { code: 'unauthorized', message: 'Unauthorized' }, headers: undefined, status: 401 });
+    });
 
-  it('should return the error message if `HttpError` has an exposable status code and a message set', () => {
-    mapper.map(new HttpError(401, 'Foo')).should.eql({ body: { code: 'unauthorized', message: 'Foo' }, status: 401 });
-    mapper.map(new HttpError('Foo', 401)).should.eql({ body: { code: 'unauthorized', message: 'Foo' }, status: 401 });
+    it('should return `HttpError` message and its code in snake case format', () => {
+      mapper.map(new HttpError(401, 'Foo Bar')).should.eql({ body: { code: 'foo_bar', message: 'Foo Bar' }, headers: undefined, status: 401 });
+    });
+
+    it('should return `HttpError` headers', () => {
+      mapper.map(new HttpError(401, 'foo', { headers: { biz: 'baz' } })).should.eql({ body: { code: 'foo', message: 'foo' }, headers: { biz: 'baz' }, status: 401 });
+    });
   });
 });


### PR DESCRIPTION
This PR updates the `HttpErrorMapper` to handle errors created through [http-standard-error](https://github.com/moll/js-standard-http-error) since the use of [http-errors](https://github.com/jshttp/http-errors) has been deprecated.

Some considerable changes:

* The `expose` property is no longer taken in consideration on the error evaluation;

* The response `message` is always the error message, since it's assigned both on HttpError and koa errors;

* The response `code` is always the error message on snake case format;

* The response also includes the error `headers`;